### PR TITLE
chore: upgrade Kotlin from 1.9.25 to 2.2.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation"org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'com.github.sanemat:maven-number-to-vietnamese:0.5.0'

--- a/app/src/main/java/jp/sane/numbersinvietnamese/MainActivity.kt
+++ b/app/src/main/java/jp/sane/numbersinvietnamese/MainActivity.kt
@@ -6,7 +6,8 @@ import android.speech.tts.TextToSpeech
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import android.view.View
-import java.util.*
+import kotlin.random.Random
+import java.util.Locale
 
 import jp.sane.numbertovietnamese.numberToVietnamese
 import jp.sane.numbersinvietnamese.databinding.ActivityMainBinding
@@ -132,10 +133,10 @@ fun booleanToVisibility(bool: Boolean): Int {
 }
 
 fun getNumber() : Int {
-    return when (Random().nextInt(99)) {
-        in 0..39 -> Random().nextInt(9) // 0-9
-        in 40..79 -> Random().nextInt(89) + 10 // 10-99
-        in 80..89 -> Random().nextInt(899) + 100 // 100-999
+    return when (Random.nextInt(99)) {
+        in 0..39 -> Random.nextInt(9) // 0-9
+        in 40..79 -> Random.nextInt(89) + 10 // 10-99
+        in 80..89 -> Random.nextInt(899) + 100 // 100-999
         in 90..92 -> 103
         in 93..96 -> 1000
         in 97..99 -> 1000000

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.9.25'
+    ext.kotlin_version = '2.2.0'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Summary
- Upgrade Kotlin version from 1.9.25 to 2.2.0 for latest language features and performance improvements
- Update dependency from kotlin-stdlib-jdk7 to kotlin-stdlib for Kotlin 2.x compatibility
- Migrate from deprecated java.util.Random to modern kotlin.random.Random API

## Test plan
- [x] Run unit tests - all pass
- [x] Run lint checks - no issues found
- [x] Verify application builds successfully
- [x] Confirm all imports are correct and modern Kotlin APIs are used

🤖 Generated with [Claude Code](https://claude.ai/code)